### PR TITLE
Store IDs in delayed_messages in memory, not Discord objects

### DIFF
--- a/gigglebot.py
+++ b/gigglebot.py
@@ -25,15 +25,15 @@ class DelayedMessage:
         self.description = description
         self.content = content
 
-    async def guild():
+    async def guild(self):
         return discord.utils.get(client.guilds, id=self.guild_id)
 
-    async def delivery_channel():
+    async def delivery_channel(self):
         guild = discord.utils.get(client.guilds, id=self.guild_id)
         return discord.utils.get(guild.text_channels, id=self.delivery_channel_id)
 
-    async def author():
-        return client.get_user(author_id)
+    async def author(self):
+        return client.get_user(self.author_id)
 
     @staticmethod
     def id_gen(id):
@@ -308,10 +308,12 @@ async def list_all_delay_messages(message):
         for guild_id in delayed_messages:
             for msg_id in delayed_messages[guild_id]:
                 msg = delayed_messages[guild_id][msg_id]
+                author = await msg.author()
+                delivery_channel = await msg.delivery_channel()
                 output += f"> \n> **ID:**  {msg.id}\n"
-                output += f"> **Author:**  {msg.author().name}\n"
+                output += f"> **Author:**  {author.name}\n"
                 output += f"> **Server:**  {client.get_guild(guild_id)}\n"
-                output += f"> **Channel:**  {msg.delivery_channel().name}\n"
+                output += f"> **Channel:**  {delivery_channel.name}\n"
                 if round((msg.delivery_time - time())/60, 1) < 0:
                     output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
                 else:

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -310,7 +310,7 @@ async def list_all_delay_messages(message):
                 msg = delayed_messages[guild_id][msg_id]
                 output += f"> \n> **ID:**  {msg.id}\n"
                 output += f"> **Author:**  {msg.author().name}\n"
-                output += f"> **Server:**  {msg.guild().name)}\n"
+                output += f"> **Server:**  {msg.guild().name}\n"
                 output += f"> **Channel:**  {msg.delivery_channel().name}\n"
                 if round((msg.delivery_time - time())/60, 1) < 0:
                     output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -25,14 +25,14 @@ class DelayedMessage:
         self.description = description
         self.content = content
 
-    async def guild(self):
+    def guild(self):
         return discord.utils.get(client.guilds, id=self.guild_id)
 
-    async def delivery_channel(self):
+    def delivery_channel(self):
         guild = discord.utils.get(client.guilds, id=self.guild_id)
         return discord.utils.get(guild.text_channels, id=self.delivery_channel_id)
 
-    async def author(self):
+    def author(self):
         return client.get_user(self.author_id)
 
     @staticmethod
@@ -255,8 +255,7 @@ def replace_mentions(content, guild_id):
 
 async def schedule_delay_message(message):
 
-    guild = await message.guild()
-    delivery_channel = await message.delivery_channel()
+    guild = message.guild()
 
     if message.delivery_time == 0:
         delay = 0
@@ -277,7 +276,7 @@ async def schedule_delay_message(message):
             except:
                 # At this point, we'll just leave {role} in the message
                 pass
-            await delivery_channel.send(content)
+            await message.delivery_channel.send(content)
             delayed_messages[guild.id].pop(message.id)
             if len(delayed_messages[guild.id]) < 1:
                 del delayed_messages[guild.id]
@@ -290,15 +289,13 @@ async def list_delay_messages(message):
 
         for msg_id in sorted_messages:
             msg = delayed_messages[message.guild.id][msg_id]
-            author = await msg.author()
-            delivery_channel = await msg.delivery_channel()
             output += f"> \n> **ID:**  {msg.id}\n"
-            output += f"> **Author:**  {author.name}\n"
-            output += f"> **Channel:**  {delivery_channel.name}\n"
+            output += f"> **Author:**  {msg.author().name}\n"
+            output += f"> **Channel:**  {msg.delivery_channel().name}\n"
             if round((msg.delivery_time - time())/60, 1) < 0:
                 output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
             else:
-                output += f"> **Deliver:**  {display_localized_time(author.id, msg.delivery_time)}\n"
+                output += f"> **Deliver:**  {display_localized_time(message.author.id, msg.delivery_time)}\n"
             output += f"> **Description:**  {msg.description}\n"
         await message.channel.send(output + "> \n> **====================**\n")
     else:
@@ -311,12 +308,10 @@ async def list_all_delay_messages(message):
         for guild_id in delayed_messages:
             for msg_id in delayed_messages[guild_id]:
                 msg = delayed_messages[guild_id][msg_id]
-                author = await msg.author()
-                delivery_channel = await msg.delivery_channel()
                 output += f"> \n> **ID:**  {msg.id}\n"
-                output += f"> **Author:**  {author.name}\n"
-                output += f"> **Server:**  {client.get_guild(guild_id)}\n"
-                output += f"> **Channel:**  {delivery_channel.name}\n"
+                output += f"> **Author:**  {msg.author().name}\n"
+                output += f"> **Server:**  {msg.guild().name)}\n"
+                output += f"> **Channel:**  {msg.delivery_channel().name}\n"
                 if round((msg.delivery_time - time())/60, 1) < 0:
                     output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
                 else:
@@ -373,10 +368,8 @@ async def show_delay_message(message, msg_num):
         for msg_id in delayed_messages[guild_id]:
             if msg_id == msg_num:
                 msg = delayed_messages[guild_id][msg_id]
-                author = await msg.author()
-                delivery_channel = await msg.delivery_channel()
-                content = f"**Author:**  {author.name}\n"
-                content += f"**Deliver to:**  {delivery_channel.name}\n"
+                content = f"**Author:**  {msg.author().name}\n"
+                content += f"**Deliver to:**  {msg.delivery_channel().name}\n"
                 if round((msg.delivery_time - time())/60, 1) < 0:
                     content += f"**Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
                 else:

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -298,7 +298,7 @@ async def list_delay_messages(message):
             if round((msg.delivery_time - time())/60, 1) < 0:
                 output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
             else:
-                output += f"> **Deliver:**  {display_localized_time(message.author().id, msg.delivery_time)}\n"
+                output += f"> **Deliver:**  {display_localized_time(author.id, msg.delivery_time)}\n"
             output += f"> **Description:**  {msg.description}\n"
         await message.channel.send(output + "> \n> **====================**\n")
     else:
@@ -443,12 +443,14 @@ async def edit_delay_message(message, message_id, delay, channel, description, c
             embed = discord.Embed(description="Message edited", color=0x00ff00)
             if channel:
                 msg.delivery_channel_id = delivery_channel.id
-                embed.add_field(name="Channel", value=f"{msg.delivery_channel.name}", inline=False)
+                embed.add_field(name="Channel", value=f"{delivery_channel.name}", inline=False)
             if description:
                 msg.description = description
+                embed.add_field(name="Description", value=f"{description}", inline=False)
             if content:
                 msg.content = content
             if delay:
+                loop = asyncio.get_event_loop()
                 newMessage =  DelayedMessage(msg.id, msg.guild_id, msg.delivery_channel_id, delivery_time, msg.author_id, msg.description, msg.content)
                 if message.guild.id not in delayed_messages:
                     delayed_messages[message.guild.id] = {}
@@ -457,7 +459,7 @@ async def edit_delay_message(message, message_id, delay, channel, description, c
                     embed.add_field(name="Deliver", value="Now", inline=False)
                 else:
                     embed.add_field(name="Deliver", value=f"{display_localized_time(message.author.id, newMessage.delivery_time)}", inline=False)
-                await schedule_delay_message(newMessage)
+                loop.create_task(schedule_delay_message(newMessage))
                 update_db(newMessage)
             else:
                 update_db(msg)

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -276,7 +276,7 @@ async def schedule_delay_message(message):
             except:
                 # At this point, we'll just leave {role} in the message
                 pass
-            await message.delivery_channel.send(content)
+            await message.delivery_channel().send(content)
             delayed_messages[guild.id].pop(message.id)
             if len(delayed_messages[guild.id]) < 1:
                 del delayed_messages[guild.id]

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -255,7 +255,8 @@ def replace_mentions(content, guild_id):
 
 async def schedule_delay_message(message):
 
-    guild = message.guild()
+    guild = await message.guild()
+    delivery_channel = await message.delivery_channel()
 
     if message.delivery_time == 0:
         delay = 0
@@ -276,7 +277,7 @@ async def schedule_delay_message(message):
             except:
                 # At this point, we'll just leave {role} in the message
                 pass
-            await message.delivery_channel().send(content)
+            await delivery_channel.send(content)
             delayed_messages[guild.id].pop(message.id)
             if len(delayed_messages[guild.id]) < 1:
                 del delayed_messages[guild.id]
@@ -289,9 +290,11 @@ async def list_delay_messages(message):
 
         for msg_id in sorted_messages:
             msg = delayed_messages[message.guild.id][msg_id]
+            author = await msg.author()
+            delivery_channel = await msg.delivery_channel()
             output += f"> \n> **ID:**  {msg.id}\n"
-            output += f"> **Author:**  {msg.author().name}\n"
-            output += f"> **Channel:**  {msg.delivery_channel().name}\n"
+            output += f"> **Author:**  {author.name}\n"
+            output += f"> **Channel:**  {delivery_channel.name}\n"
             if round((msg.delivery_time - time())/60, 1) < 0:
                 output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
             else:
@@ -370,8 +373,10 @@ async def show_delay_message(message, msg_num):
         for msg_id in delayed_messages[guild_id]:
             if msg_id == msg_num:
                 msg = delayed_messages[guild_id][msg_id]
-                content = f"**Author:**  {msg.author().name}\n"
-                content += f"**Deliver to:**  {msg.delivery_channel().name}\n"
+                author = await msg.author()
+                delivery_channel = await msg.delivery_channel()
+                content = f"**Author:**  {author.name}\n"
+                content += f"**Deliver to:**  {delivery_channel.name}\n"
                 if round((msg.delivery_time - time())/60, 1) < 0:
                     content += f"**Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
                 else:


### PR DESCRIPTION
The goal of doing this was so that we could run `load_from_db` prior to `client.run()`

Unfortunately, we need access to the client to schedule messages loaded from the DB.  It seems to be the only way to get the channel :(