### PR TITLE
Add repeat option

### DIFF
--- a/gigglebot.py
+++ b/gigglebot.py
@@ -31,8 +31,9 @@ async def load_from_db(delayed_messages):
         delivery_channel_id = msg[2]
         delivery_time = msg[3]
         author_id = msg[4]
-        content = msg[5]
-        description = msg[6]
+        repeat = msg[5]
+        content = msg[6]
+        description = msg[7]
 
         if message_id in delayed_messages:
 
@@ -41,20 +42,21 @@ async def load_from_db(delayed_messages):
             delayed_messages[message_id].guild_id = guild_id
             delayed_messages[message_id].delivery_channel_id = delivery_channel_id
             delayed_messages[message_id].author_id = author_id
+            delayed_messages[message_id].repeat = repeat
             delayed_messages[message_id].content = content
             delayed_messages[message_id].description = description
 
             if delayed_messages[message_id].delivery_time != delivery_time:
                 delayed_messages[message_id].delivery_time = delivery_time
 
-                newMessage =  DelayedMessage(message_id, guild_id, delivery_channel_id, delivery_time, author_id, description, content)
+                newMessage =  DelayedMessage(message_id, guild_id, delivery_channel_id, delivery_time, author_id, repeat, description, content)
                 if g_id not in delayed_messages:
                     delayed_messages = {}
                 delayed_messages[message_id] = newMessage
                 loop.create_task(schedule_delay_message(newMessage))
         else:
 
-            newMessage =  DelayedMessage(message_id, guild_id, delivery_channel_id, delivery_time, author_id, description, content)
+            newMessage =  DelayedMessage(message_id, guild_id, delivery_channel_id, delivery_time, author_id, repeat, description, content)
 
             delayed_messages[message_id] = newMessage
             if delivery_time is not None:
@@ -66,7 +68,7 @@ async def load_from_db(delayed_messages):
     gigtz.load_timezones()
     load_users()
 
-async def process_delay_message(discord_message, delay, channel, description, content):
+async def process_delay_message(discord_message, delay, channel, repeat, description, content):
 
     # get channel if provided
     if channel:
@@ -110,7 +112,7 @@ async def process_delay_message(discord_message, delay, channel, description, co
             return
 
         # create new DelayedMessage
-        newMessage =  DelayedMessage(DelayedMessage.id_gen(discord_message.id), discord_message.guild.id, delivery_channel.id, delivery_time, discord_message.author.id, description, content)
+        newMessage =  DelayedMessage(DelayedMessage.id_gen(discord_message.id), discord_message.guild.id, delivery_channel.id, delivery_time, discord_message.author.id, repeat, description, content)
         newMessage.insert_into_db()
 
         if delivery_time is None:
@@ -201,6 +203,7 @@ async def list_delay_messages(channel, author_id, list_all, templates=False):
                 output += f"> \n> **ID:**  {msg.id}\n"
                 output += f"> **Author:**  {msg.author(client).name}\n"
                 output += f"> **Channel:**  {msg.delivery_channel(client).name}\n"
+                output += f"> **Repeat:**  {msg.repeat}\n"
                 if not templates:
                     if round((msg.delivery_time - time())/60, 1) < 0:
                         output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
@@ -253,7 +256,8 @@ async def show_delayed_message(channel, author_id, msg_num, raw):
     if msg_num in delayed_messages:
         msg = delayed_messages[msg_num]
         content += f"**Author:**  {msg.author(client).name}\n"
-        content += f"**Deliver to:**  {msg.delivery_channel(client).name}\n"
+        content += f"**Channel:**  {msg.delivery_channel(client).name}\n"
+        content += f"> **Repeat:**  {msg.repeat}\n"
         if channel.guild.id != msg.guild_id:
             content += f"**Deliver in:**  {channel.guild.name}\n"
         if msg.delivery_time is not None:
@@ -306,6 +310,7 @@ async def edit_delay_message(params):
     message_id = params['message_id']
     delay = params['delay']
     channel = params['channel']
+    repeat = params['repeat']
     description = params['description']
     content = params['content']
     author = params['author']
@@ -313,8 +318,8 @@ async def edit_delay_message(params):
     need_to_confirm = False
     type = "Message"
 
-    if not delay and not channel and not description and not content:
-        await discord_message.channel.send(embed=discord.Embed(description="You must modify at least one of time, channel, description, or content"))
+    if not delay and not channel and not repeat and not description and not content:
+        await discord_message.channel.send(embed=discord.Embed(description="You must modify at least one of time, channel, repeat, description, or content"))
         return
 
     if message_id == 'last':
@@ -363,7 +368,7 @@ async def edit_delay_message(params):
 
         if need_to_confirm:
             await confirm_request(discord_message.channel, author, f"Edit message {message_id}?", 10, edit_delay_message,
-                {'discord_message': discord_message, 'message_id': message_id, 'delay': delay, 'channel': channel, 'description': description, 'content': content, 'author': author}, client)
+                    {'discord_message': discord_message, 'message_id': message_id, 'delay': delay, 'channel': channel, 'repeat': repeat, 'description': description, 'content': content, 'author': author}, client)
             return
 
         embed = discord.Embed(description=f"{type} edited", color=0x00ff00)
@@ -377,7 +382,7 @@ async def edit_delay_message(params):
             msg.content = content
         if delay:
             loop = asyncio.get_event_loop()
-            newMessage =  DelayedMessage(msg.id, msg.guild_id, msg.delivery_channel_id, delivery_time, msg.author_id, msg.description, msg.content)
+            newMessage =  DelayedMessage(msg.id, msg.guild_id, msg.delivery_channel_id, delivery_time, msg.author_id, msg.repeat, msg.description, msg.content)
             delayed_messages[msg.id] = newMessage
             if delivery_time == 0:
                 embed.add_field(name="Deliver", value="Now", inline=False)
@@ -502,15 +507,15 @@ async def on_message(msg):
                 await send_delay_message({'channel': msg.channel, 'author': msg.author, 'msg_num': match.group(2)})
                 return
 
-            match = re.search(r'^~g(iggle)? +edit +(\S+)(( +)(\d{4}-\d{1,2}-\d{1,2} +\d{1,2}:\d{1,2}(:\d{1,2})?|-?\d+))?(( +channel=)(\S+))?(( +desc=")([^"]+)")? *((\n)(.*))?$', msg.content, re.MULTILINE|re.DOTALL)
+            match = re.search(r'^~g(iggle)? +edit +(\S+)(( +)(\d{4}-\d{1,2}-\d{1,2} +\d{1,2}:\d{1,2}(:\d{1,2})?|-?\d+))?(( +channel=)(\S+))?(( +repeat=)(none|daily|weekly|monthly))?(( +desc=")([^"]+)")? *((\n)(.*))?$', msg.content, re.MULTILINE|re.DOTALL)
             if match:
                 await edit_delay_message({'discord_message': msg, 'message_id': match.group(2), 'delay': match.group(5),
-                    'channel': match.group(9), 'description': match.group(12), 'content': match.group(15), 'author': msg.author})
+                    'channel': match.group(9), 'repeat': match.group(12), 'description': match.group(15), 'content': match.group(18), 'author': msg.author})
                 return
 
-            match = re.search(r'^~g(iggle)? +(\d{4}-\d{1,2}-\d{1,2} +\d{1,2}:\d{1,2}(:\d{1,2})?|-?\d+|template)(( +channel=)(\S+))?(( +desc=")([^"]+)")? *((\n)(.+))$', msg.content, re.MULTILINE|re.DOTALL)
+            match = re.search(r'^~g(iggle)? +(\d{4}-\d{1,2}-\d{1,2} +\d{1,2}:\d{1,2}(:\d{1,2})?|-?\d+|template)(( +channel=)(\S+))?(( +repeat=)(daily|weekly|monthly))?(( +desc=")([^"]+)")? *((\n)(.+))$', msg.content, re.MULTILINE|re.DOTALL)
             if match:
-                await process_delay_message(msg, match.group(2), match.group(6), match.group(9), match.group(12))
+                await process_delay_message(msg, match.group(2), match.group(6), match.group(9), match.group(12), match.group(15))
                 return
 
             if re.search(r'^~g(iggle)? +resume *$', msg.content) and msg.author.id == 669370838478225448:

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -92,6 +92,9 @@ async def process_delay_message(discord_message, delay, channel, repeat, descrip
     else:
         if delay == 'template':
             delivery_time = None
+            if repeat is not None:
+                await discord_message.channel.send(embed=discord.Embed(description="The repeat option may not be used when creating a template", color=0xff0000))
+                return
         elif re.search(r'^-?\d+$', delay):
             if delay == '0':
                 delivery_time = 0
@@ -203,8 +206,8 @@ async def list_delay_messages(channel, author_id, list_all, templates=False):
                 output += f"> \n> **ID:**  {msg.id}\n"
                 output += f"> **Author:**  {msg.author(client).name}\n"
                 output += f"> **Channel:**  {msg.delivery_channel(client).name}\n"
-                output += f"> **Repeat:**  {msg.repeat}\n"
                 if not templates:
+                    output += f"> **Repeat:**  {msg.repeat}\n"
                     if round((msg.delivery_time - time())/60, 1) < 0:
                         output += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
                     else:
@@ -252,22 +255,22 @@ async def show_delayed_message(channel, author_id, msg_num, raw):
     if msg_num == 'last':
         if author_id in users:
             msg_num = users[author_id].last_message_id
-            content += f"**ID:**  {msg_num}\n"
+            content += f"> **ID:**  {msg_num}\n"
     if msg_num in delayed_messages:
         msg = delayed_messages[msg_num]
-        content += f"**Author:**  {msg.author(client).name}\n"
-        content += f"**Channel:**  {msg.delivery_channel(client).name}\n"
+        content += f"> **Author:**  {msg.author(client).name}\n"
+        content += f"> **Channel:**  {msg.delivery_channel(client).name}\n"
         content += f"> **Repeat:**  {msg.repeat}\n"
         if channel.guild.id != msg.guild_id:
-            content += f"**Deliver in:**  {channel.guild.name}\n"
+            content += f"> **Deliver in:**  {channel.guild.name}\n"
         if msg.delivery_time is not None:
             if round((msg.delivery_time - time())/60, 1) < 0:
-                content += f"**Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
+                content += f"> **Delivery failed:**  {str(round((msg.delivery_time - time())/60, 1) * -1)} minutes ago\n"
             else:
-                content += f"**Deliver:**  {gigtz.display_localized_time(msg.delivery_time, users[author_id].timezone)}\n"
+                content += f"> **Deliver:**  {gigtz.display_localized_time(msg.delivery_time, users[author_id].timezone)}\n"
         else:
-            content = "**Template**\n" + content
-        content += f"**Description:**  {msg.description}\n"
+            content = "> **Template**\n" + content
+        content += f"> **Description:**  {msg.description}\n"
         await channel.send(content)
         if raw:
             await channel.send("```\n" + msg.content + "\n```")
@@ -331,6 +334,9 @@ async def edit_delay_message(params):
         msg = delayed_messages[message_id]
         if msg.delivery_time == None:
             type = "Template"
+            if repeat is not None:
+                await discord_message.channel.send(embed=discord.Embed(description="The repeat option may not be used when editing a template", color=0xff0000))
+                return
 
         if delay:
             if msg.delivery_time == None:

--- a/gigglebot.py
+++ b/gigglebot.py
@@ -375,6 +375,9 @@ async def edit_delay_message(params):
         if channel:
             msg.delivery_channel_id = delivery_channel.id
             embed.add_field(name="Channel", value=f"{delivery_channel.name}", inline=False)
+        if repeat:
+            msg.repeat = repeat
+            embed.add_field(name="Repeat", value=f"{repeat}", inline=False)
         if description:
             msg.description = description
             embed.add_field(name="Description", value=f"{description}", inline=False)

--- a/util/delayed_message.py
+++ b/util/delayed_message.py
@@ -4,12 +4,13 @@ from hashlib import md5
 from gigdb import db_connect
 
 class DelayedMessage:
-    def __init__(self, id, guild_id, delivery_channel_id, delivery_time, author_id, description, content):
+    def __init__(self, id, guild_id, delivery_channel_id, delivery_time, author_id, repeat, description, content):
         self.id = id
         self.guild_id = guild_id
         self.delivery_channel_id = delivery_channel_id
         self.delivery_time = delivery_time
         self.author_id = author_id
+        self.repeat = repeat
         self.description = description
         self.content = content
 
@@ -31,8 +32,8 @@ class DelayedMessage:
         mydb = db_connect()
 
         mycursor = mydb.cursor()
-        sql = "INSERT INTO messages values (%s, %s, %s, %s, %s, %s, %s)"
-        mycursor.execute(sql, (self.id, self.guild_id, self.delivery_channel_id, self.delivery_time, self.author_id, self.content, self.description))
+        sql = "INSERT INTO messages values (%s, %s, %s, %s, %s, %s, %s, %s)"
+        mycursor.execute(sql, (self.id, self.guild_id, self.delivery_channel_id, self.delivery_time, self.author_id, self.repeat, self.content, self.description))
         mydb.commit()
         mycursor.close()
         mydb.disconnect()
@@ -41,8 +42,8 @@ class DelayedMessage:
         mydb = db_connect()
 
         mycursor = mydb.cursor()
-        sql = "UPDATE messages SET guild_id = %s, delivery_channel_id = %s, delivery_time =  %s, author_id = %s, content = %s, description = %s WHERE id = %s"
-        mycursor.execute(sql, (self.guild_id, self.delivery_channel_id, self.delivery_time, self.author_id, self.content, self.description, self.id))
+        sql = "UPDATE messages SET guild_id = %s, delivery_channel_id = %s, delivery_time =  %s, author_id = %s, repeats = %s, content = %s, description = %s WHERE id = %s"
+        mycursor.execute(sql, (self.guild_id, self.delivery_channel_id, self.delivery_time, self.author_id, self.repeat, self.content, self.description, self.id))
         mydb.commit()
         mycursor.close()
         mydb.disconnect()

--- a/util/gigtz.py
+++ b/util/gigtz.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from datetime import datetime
 from pytz import timezone
+from dateutil.relativedelta import relativedelta
 import gigdb
 
 timezones = {}
@@ -41,3 +42,41 @@ def load_timezones():
     mycursor.close()
     mydb.disconnect()
 
+def add_day(time, tz_id):
+    tz = timezone(timezones[tz_id].name)
+    from_dt = datetime.fromtimestamp(time)
+    to_dt = datetime.fromtimestamp(time) + relativedelta(days=+100)
+    time = to_dt.timestamp()
+    if not from_dt.astimezone(tz).dst() and to_dt.astimezone(tz).dst():
+        to_dt = datetime.fromtimestamp(time) + relativedelta(hours=-1)
+    elif from_dt.astimezone(tz).dst() and not to_dt.astimezone(tz).dst():
+        to_dt = datetime.fromtimestamp(time) + relativedelta(hours=+1)
+    else:
+        to_dt = datetime.fromtimestamp(time)
+    return to_dt.timestamp()
+
+def add_week(time, tz_id):
+    tz = timezone(timezones[tz_id].name)
+    from_dt = datetime.fromtimestamp(time)
+    to_dt = datetime.fromtimestamp(time) + relativedelta(weeks=+18)
+    time = to_dt.timestamp()
+    if not from_dt.astimezone(tz).dst() and to_dt.astimezone(tz).dst():
+        to_dt = datetime.fromtimestamp(time) + relativedelta(hours=-1)
+    elif from_dt.astimezone(tz).dst() and not to_dt.astimezone(tz).dst():
+        to_dt = datetime.fromtimestamp(time) + relativedelta(hours=+1)
+    else:
+        to_dt = datetime.fromtimestamp(time)
+    return to_dt.timestamp()
+
+def add_month(time, tz_id):
+    tz = timezone(timezones[tz_id].name)
+    from_dt = datetime.fromtimestamp(time)
+    to_dt = datetime.fromtimestamp(time) + relativedelta(months=+1)
+    time = to_dt.timestamp()
+    if not from_dt.astimezone(tz).dst() and to_dt.astimezone(tz).dst():
+        to_dt = datetime.fromtimestamp(time) + relativedelta(hours=-1)
+    elif from_dt.astimezone(tz).dst() and not to_dt.astimezone(tz).dst():
+        to_dt = datetime.fromtimestamp(time) + relativedelta(hours=+1)
+    else:
+        to_dt = datetime.fromtimestamp(time)
+    return to_dt.timestamp()

--- a/util/help.py
+++ b/util/help.py
@@ -4,7 +4,7 @@ def show_help(command):
     if not command:
         return """To schedule <message> to be delivered to <channel> at <time>:
 
-        `~giggle <time> channel=<channel> desc="<brief description>"`
+        `~giggle <time> channel=<channel> repeat=<frequency> desc="<brief description>"`
         `<message>`
 
         <time> may be either a number of minutes from now
@@ -12,13 +12,19 @@ def show_help(command):
         All times are UTC unless you have set your local
         time with the `~giggle timezone` command
 
+        repeat is an optional.  If included, your message will be repeated at
+        the given frequency until you cancel the message or edit it with repeat=none
+        <frequency> may be daily, weekly, or monthly
+
         desc is an optional description of the message
-        If included, it must come after channel and be surrounded by double quotes
 
         To create a template:
 
         `~giggle template channel=<channel> desc="<brief description>"`
         `<message>`
+
+        Note:  For both messages and templates, the optionsl parameters (when provided)
+        must appear in the order shown above
 
         The following commands may be used to manage scheduled messages:
 
@@ -61,24 +67,29 @@ def show_help(command):
         """
 
     if command == "edit":
-        return """`~giggle edit <message-id> <time> channel=<channel> desc="<desc>"`
+        return """`~giggle edit <message-id> <time> channel=<channel> repeat=<frequency> desc="<desc>"`
         `<message>`
 
         Edit message identified by <message-id>.
-        
+
         <time> may be either a number of minutes from now or a DateTime of the format YYYY-MM-DD HH:MM(:SS)
         If not specified, the current delivery time will be used.
         All times are UTC unless you have set your local time with the `~giggle timezone` command
 
         channel=<channel> is optional.  If not specified, the current delivery channel will be used.
 
-        desc="<desc>" is optional.  If both channel and desc are included, desc must come after channel
+        repeat is an optional.  If included, your message will be repeated at
+        the given frequency until you cancel the message or edit it with repeat=none
+        <frequency> may be none, daily, weekly, or monthly
+
+        desc is an optional description of the message
 
         <message> is optional.  If specified, it will replace the body of the current message.
 
         Note:  `last` may be used as <message-id> to reference your most recently scheduled message
+        The optional parameters to the command (when provided) must appear in the order above
 
-        `edit` may be used to edit templates.  When editing a template, the <time> option is not allowed
+        `edit` may be used to edit templates.  When editing a template, the <time> and repeat options are not allowed
         """
 
     if command == "cancel":


### PR DESCRIPTION
This implements the repeat option (daily, weekly, or monthly) but does not implement the "wishful thinking" below.  We'll do that in a separate PR

> Wishful thinking: If the bot could see if its own last iteration was the most recent post in the channel, skip the new post* or replace the old post to update the timestamp**
> 
> *preferred
**fancier