### PR TITLE
Remove unused twitter columns from guilds table

### DIFF
--- a/gigglebot.py
+++ b/gigglebot.py
@@ -933,11 +933,6 @@ async def show_guild_config(msg):
         output += get_channel_by_name_or_id(msg.guild, gigguild.guilds[msg.guild.id].delivery_channel_id).mention
     except:
         output += str(gigguild.guilds[msg.guild.id].delivery_channel_id)
-    output += "\n**tweet_channel**:  "
-    try:
-        output += get_channel_by_name_or_id(msg.guild, gigguild.guilds[msg.guild.id].tweet_channel_id).mention
-    except:
-        output += str(gigguild.guilds[msg.guild.id].tweet_channel_id)
     await msg.channel.send(embed=discord.Embed(description=output, color=0x00ff00))
 
 async def set_guild_config(params):

--- a/util/gigdb.py
+++ b/util/gigdb.py
@@ -88,14 +88,11 @@ def set_user_format_24(format_24, user_id):
 def set_user_timezone(tz_id, name, user_id):
     db_execute_sql("UPDATE users SET timezone = %s, name = %s WHERE user = %s", False, tz_id=tz_id, name=name, user_id=user_id)
 
-def save_guild(id, guild_name, proposal_channel_id, approval_channel_id, delivery_channel_id, tweet_channel_id, twitter_access_token_key, twitter_access_token_secret):
-    db_execute_sql("INSERT INTO guilds ( id, guild_name, proposal_channel_id, approval_channel_id, delivery_channel_id, tweet_channel_id, twitter_access_token_key, twitter_access_token_secret ) "
-            "values (%s, %s, %s, %s, %s, %s, %s, %s) ON DUPLICATE KEY UPDATE guild_name = %s, proposal_channel_id = %s, approval_channel_id = %s, delivery_channel_id = %s, "
-            "tweet_channel_id = %s, twitter_access_token_key = %s, twitter_access_token_secret = %s",
+def save_guild(id, guild_name, proposal_channel_id, approval_channel_id, delivery_channel_id):
+    db_execute_sql("INSERT INTO guilds ( id, guild_name, proposal_channel_id, approval_channel_id, delivery_channel_id ) "
+            "values (%s, %s, %s, %s, %s) ON DUPLICATE KEY UPDATE guild_name = %s, proposal_channel_id = %s, approval_channel_id = %s, delivery_channel_id = %s",
             False, id=id, guild_name=guild_name, proposal_channel_id=proposal_channel_id, approval_channel_id=approval_channel_id, delivery_channel_id=delivery_channel_id,
-            tweet_channel_id=tweet_channel_id, twitter_access_token_key=twitter_access_token_key, twitter_access_token_secret=twitter_access_token_secret,
-            guild_name_2=guild_name, proposal_channel_id_2=proposal_channel_id, approval_channel_id_2=approval_channel_id, delivery_channel_id_2=delivery_channel_id,
-            tweet_channel_id_2=tweet_channel_id, twitter_access_token_key_2=twitter_access_token_key, twitter_access_token_secret_2=twitter_access_token_secret)
+            guild_name_2=guild_name, proposal_channel_id_2=proposal_channel_id, approval_channel_id_2=approval_channel_id, delivery_channel_id_2=delivery_channel_id)
 
 def save_channel(id, guild_id, name, channel_type, token_key, token_secret, user_id, screen_name):
     db_execute_sql("INSERT INTO channels ( id, guild_id, name, channel_type, token_key, token_secret, user_id, screen_name) values (%s, %s, %s, %s, %s, %s, %s, %s) "

--- a/util/gigguild.py
+++ b/util/gigguild.py
@@ -4,19 +4,16 @@ import gigdb
 guilds = {}
 
 class Guild:
-    def __init__(self, id, guild_name, proposal_channel_id=None, approval_channel_id=None, delivery_channel_id=None, tweet_channel_id=None, twitter_access_token_key=None, twitter_access_token_secret=None):
+    def __init__(self, id, guild_name, proposal_channel_id=None, approval_channel_id=None, delivery_channel_id=None):
         self.id = id
         self.guild_name = guild_name
         self.proposal_channel_id = proposal_channel_id
         self.approval_channel_id = approval_channel_id
         self.delivery_channel_id = delivery_channel_id
-        self.tweet_channel_id = tweet_channel_id
-        self.twitter_access_token_key = twitter_access_token_key
-        self.twitter_access_token_secret = twitter_access_token_secret
         self.save()
 
     def save(self):
-        gigdb.save_guild(self.id, self.guild_name, self.proposal_channel_id, self.approval_channel_id, self.delivery_channel_id, self.tweet_channel_id, self.twitter_access_token_key, self.twitter_access_token_secret)
+        gigdb.save_guild(self.id, self.guild_name, self.proposal_channel_id, self.approval_channel_id, self.delivery_channel_id)
 
     def set_proposal_channel_id(self, proposal_channel_id):
         self.proposal_channel_id = proposal_channel_id
@@ -32,4 +29,4 @@ class Guild:
 
 def load_guilds():
     for row in gigdb.get_all("guilds"):
-        guilds[row[0]] = Guild(row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7])
+        guilds[row[0]] = Guild(row[0], row[1], row[2], row[3], row[4])


### PR DESCRIPTION
After this commit is merged, all twitter related columns can be removed
from the guilds table